### PR TITLE
Token LUA Notifications & Atrium Exterior Render Logic

### DIFF
--- a/Room_collabmuseum/lua_chazzyb_tokens.lua
+++ b/Room_collabmuseum/lua_chazzyb_tokens.lua
@@ -1,0 +1,85 @@
+if callType == LuaCallType.Init then
+	token_count = 0;
+
+elseif callType == LuaCallType.TriggerExit then
+    if context == token01 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token02 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token03 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token04 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token05 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token06 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token07 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token08 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token09 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token10 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token11 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token12 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token13 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token14 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token15 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+    if context == token16 then
+        token_count = token_count + 1;
+	api.levelNote("\bYou found a token!\nTokens can be spent in the gift shop, found in the atrium.\n["..token_count.."/16 found]");
+	end
+
+end


### PR DESCRIPTION
- Added triggers and render logic for atrium exterior. Exterior dome should only render in once players can begin to see it through the atrium door windows. Not sure if there will be much performance boost, but doesn't seem to hurt anything at the moment.

- Fixed players being able to ride elevator from outside by shrinking trigger zone, adding colliders, and adding a second trigger zone for the "Waiting" sign logic. Closes #158

- Added preliminary token pickup notifications via LUA. Still need to sort solution for sounds triggering when areas render out/render in. Closes #144