### PR TITLE
Franch Balloon animation

### DIFF
--- a/Room_collabmuseum/lua_franch_balloon_rotation.lua
+++ b/Room_collabmuseum/lua_franch_balloon_rotation.lua
@@ -1,0 +1,19 @@
+-- From Thoroniul's LUA Tutorial: https://steamcommunity.com/sharedfiles/filedetails/?id=2809817128
+
+if callType == LuaCallType.Init then
+    d_theta = 3  -- angle change per second
+
+elseif callType == LuaCallType.SwitchDone then
+
+if context == balloon_rotation_cw then
+
+   balloon_rotating = true
+end
+
+ elseif callType == LuaCallType.Update then
+     if balloon_rotating == true then
+     delta = d_theta * Time.deltaTime
+   balloon_rotation_cw.transform.Rotate(0,delta,0)
+   end
+
+end


### PR DESCRIPTION
Commit 1:
- Deleted Trigger5 which toggles exterior dome on/off when player is on the balcony - replacing this by turning dome on permanently when player clicks Exit doors
- Added preliminary Balloon ride animation logic + parenting + Lua script. Turn on Debug mode to access it (and ignore temporary Finish for playtesters, by clicking Stay)
- Updated Whale Collectible texture in Gift Shop

Commit 2:
- Add preliminary Finish flag logic and test button
- Disable initial Duc VO if you hit Debug button before it starts
- More subtle button on balcony to trigger balloon arrival, to not attract attention of playtesters - now located next to railing, behind lightpole on the left
- Adjusted snowglobe visibility...for some reason, nothing appeared to be connected to the Viz activators to enable it and it was disabled on start. I linked this to elevator Up / Down for now, but Down /Disable has a kill switch once the snowglobe is picked up.